### PR TITLE
add sort by newest date to mdToApi

### DIFF
--- a/lib/md-to-api.js
+++ b/lib/md-to-api.js
@@ -44,6 +44,7 @@ module.exports = function mdToApi(options = { source: 'src/content', target: 'pu
         },
         async writeBundle() {
             return new Promise(async (resolve, reject) => {
+                finalBlob.sort((a, b) => a.date < b.date ? 1 : -1);
                 const blobPath = path.resolve(target, '__blog-blob.json');
                 const written = await fs.writeFile(blobPath, JSON.stringify(finalBlob));
                 resolve();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scant",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A static site generator for Svelte.",
   "bin": {
     "scant": "bin/index.js"


### PR DESCRIPTION
So going off examples in https://github.com/sveltejs/svelte/blob/a6c05ed3728c7b3b2e08fdb83fa58ab46a58ad5f/site/src/routes/blog/_posts.js#L68 and https://github.com/sveltejs/sapper-template/blob/0fa6c9f7d7ca0933370a985e1178df3754eb8ce7/routes/blog/_posts.js#L11 I added sorting by newest date to `lib/md-to-api.js` and bumped version in `package.json` to `0.0.4`.

Had similar `package-lock.json` issue mentioned in https://github.com/scantjs/scant-example-site/pull/9, but thankfully did not commit it this time. So I have same question for this repo about whether we should add it to `.gitignore` or not.

Closes #5 